### PR TITLE
refactor: Update RGB Idle Light to Light Entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _Control your BigTreeTech Panda Status via Home Assistant_
 
 - **WiFi AP** - Allows you to enable/disable the AP.
 - **RGB Idle Light** - Allows you enable/disable the idle light
-  - It just sets the brightness to 0% or 100%.
+  - Redesigned from original to be a light entity in HA with expected controls
 
 ### Select Entities
 
@@ -75,7 +75,7 @@ After installation, add the integration via Home Assistant UI:
 
 ## Support & Issues
 
-For issues or feature requests, open an [issue on GitHub](https://github.com/ping-localhost/panda-status/issues).
+For issues or feature requests, open an [issue on GitHub](https://github.com/BambamNZ/panda-status/issues).
 
 ## License
 

--- a/custom_components/panda_status/__init__.py
+++ b/custom_components/panda_status/__init__.py
@@ -7,6 +7,7 @@ https://github.com/ping-localhost/panda-status
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.const import CONF_URL, Platform
@@ -25,6 +26,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SELECT,
     Platform.SWITCH,
+    Platform.LIGHT,
 ]
 
 
@@ -38,6 +40,12 @@ async def async_setup_entry(
         hass=hass,
         logger=LOGGER,
         name=DOMAIN,
+        # Real polling, previously unset (see PR history). 30s turned out
+        # too aggressive for the device's embedded WS stack when combined
+        # with the 1s-per-connection timeout, causing frequent unavailable
+        # flaps - 60s plus the more forgiving timeout and single retry in
+        # the coordinator gives it more breathing room.
+        update_interval=timedelta(seconds=60),
     )
     entry.runtime_data = PandaStatusData(
         client=PandaStatusWebSocket(url=entry.data[CONF_URL], session=None),

--- a/custom_components/panda_status/coordinator.py
+++ b/custom_components/panda_status/coordinator.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .websocket import PandaStatusWebsocketCommunicationError, PandaStatusWebsocketError
+from .websocket import (
+    PandaStatusWebsocketCommunicationError,
+    PandaStatusWebsocketError,
+    PandaStatusWebsocketTimeoutError,
+)
 
 if TYPE_CHECKING:
     from .data import PandaStatusConfigEntry
@@ -20,10 +24,24 @@ class PandaStatusDataUpdateCoordinator(DataUpdateCoordinator):
     config_entry: PandaStatusConfigEntry
 
     async def _async_update_data(self) -> Any:
-        """Update data via library."""
-        try:
-            return await self.config_entry.runtime_data.client.async_get_data()
-        except PandaStatusWebsocketCommunicationError as exception:
-            raise ConfigEntryNotReady(exception) from exception
-        except PandaStatusWebsocketError as exception:
-            raise UpdateFailed(exception) from exception
+        """Update data via library.
+
+        A single slow/timed-out poll is retried once before being treated
+        as a real failure. With periodic polling now running continuously
+        rather than only right after user actions, occasionally catching
+        the device's embedded WS stack mid-task is expected background
+        noise, not a genuine unavailability - retrying once avoids flapping
+        entities to unavailable over what is usually just a slow beat.
+        """
+        attempts = 2
+        for attempt in range(attempts):
+            try:
+                return await self.config_entry.runtime_data.client.async_get_data()
+            except PandaStatusWebsocketTimeoutError as exception:
+                if attempt == attempts - 1:
+                    raise UpdateFailed(exception) from exception
+            except PandaStatusWebsocketCommunicationError as exception:
+                raise ConfigEntryNotReady(exception) from exception
+            except PandaStatusWebsocketError as exception:
+                raise UpdateFailed(exception) from exception
+        return None  # pragma: no cover - unreachable, loop always returns or raises

--- a/custom_components/panda_status/light.py
+++ b/custom_components/panda_status/light.py
@@ -179,4 +179,3 @@ class PandaStatusRGBIdleLight(PandaStatusEntity, LightEntity):
         self.async_write_ha_state()
 
         self.hass.async_create_task(self._async_reconcile_after_delay())
-        

--- a/custom_components/panda_status/light.py
+++ b/custom_components/panda_status/light.py
@@ -179,3 +179,4 @@ class PandaStatusRGBIdleLight(PandaStatusEntity, LightEntity):
         self.async_write_ha_state()
 
         self.hass.async_create_task(self._async_reconcile_after_delay())
+        

--- a/custom_components/panda_status/light.py
+++ b/custom_components/panda_status/light.py
@@ -90,9 +90,7 @@ class PandaStatusRGBIdleLight(PandaStatusEntity, LightEntity):
 
     def _get_brightness(self) -> int | None:
         """Get current brightness, converted from the device's 0-100 scale."""
-        device_brightness = tools.extract_value(
-            self.coordinator.data, "led.brightness"
-        )
+        device_brightness = tools.extract_value(self.coordinator.data, "led.brightness")
         if device_brightness is None:
             return None
         return round(device_brightness / 100 * 255)

--- a/custom_components/panda_status/light.py
+++ b/custom_components/panda_status/light.py
@@ -1,0 +1,181 @@
+"""Light platform for Panda Status integration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from custom_components.panda_status import tools
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.core import callback
+
+from .entity import PandaStatusEntity
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import PandaStatusDataUpdateCoordinator
+    from .data import PandaStatusConfigEntry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: PandaStatusConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the panda_status light platform."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities(
+        [
+            PandaStatusRGBIdleLight(
+                coordinator=coordinator,
+                entity_description=LightEntityDescription(
+                    key="rgb_idle_light",
+                    name="RGB Idle Light",
+                    icon="mdi:led-strip-variant",
+                ),
+            ),
+        ]
+    )
+
+
+class PandaStatusRGBIdleLight(PandaStatusEntity, LightEntity):
+    """Representation of the RGB Idle Light.
+
+    Replaces the old rgb_idle_light switch. The device exposes a real
+    on/off flag (led.on / settings.on) that is entirely separate from
+    brightness (led.brightness / settings.list2[current_mode].brightness),
+    so this is modelled as a brightness-only light rather than a switch
+    that faked "on" by slamming brightness to 100.
+
+    Confirmed via direct testing against the device: on/off must be sent
+    as a single atomic payload including settings.current_mode - the
+    device will not turn off without it.
+    """
+
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes: ClassVar[set[ColorMode]] = {ColorMode.BRIGHTNESS}
+
+    def __init__(
+        self,
+        coordinator: PandaStatusDataUpdateCoordinator,
+        entity_description: LightEntityDescription,
+    ) -> None:
+        """
+        Initialize the RGB Idle Light entity.
+
+        Args:
+            coordinator: The data update coordinator for panda_status.
+            entity_description: Description of the light entity.
+
+        """
+        super().__init__(coordinator, entity_description)
+        self.entity_description = entity_description
+        self._attr_is_on = self._get_on_state()
+        self._attr_brightness = self._get_brightness()
+
+    def _get_on_state(self) -> bool | None:
+        """Get the current on/off state from the real led.on flag."""
+        on_state = tools.extract_value(self.coordinator.data, "led.on")
+        if on_state is not None:
+            return bool(on_state)
+        return None
+
+    def _get_brightness(self) -> int | None:
+        """Get current brightness, converted from the device's 0-100 scale."""
+        device_brightness = tools.extract_value(
+            self.coordinator.data, "led.brightness"
+        )
+        if device_brightness is None:
+            return None
+        return round(device_brightness / 100 * 255)
+
+    def _current_mode(self) -> int:
+        """Get the currently active rgb_info_mode, defaulting to 0."""
+        mode = tools.extract_value(self.coordinator.data, "settings.current_mode")
+        return mode if mode is not None else 0
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = self._get_on_state()
+        self._attr_brightness = self._get_brightness()
+        self.async_write_ha_state()
+
+    async def _async_reconcile_after_delay(self) -> None:
+        """Reconcile with the device's real state after it has had time to settle.
+
+        Each command opens a brand new WebSocket connection (see
+        websocket.py) with no guarantee the device has finished applying it
+        before that connection closes. Refreshing immediately after sending
+        a command can therefore read back stale data and stomp the
+        optimistic state set in async_turn_on/async_turn_off. Waiting a
+        moment first, and running this as a background task rather than
+        blocking the service call, avoids that without making the UI feel
+        laggy.
+        """
+        await asyncio.sleep(1)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the RGB Idle Light, optionally setting brightness."""
+        settings: dict[str, Any] = {
+            "on": True,
+            "current_mode": self._current_mode(),
+        }
+        led: dict[str, Any] = {"on": True}
+
+        device_brightness: int | None = None
+        if ATTR_BRIGHTNESS in kwargs:
+            # HA brightness is 0-255, device wants a 1-100 percentage.
+            # Clamp to 1 rather than 0 - a 0% brightness "on" call would
+            # visually look off but leave the device in an on/on state
+            # mismatched with what the user asked for; turn_off handles
+            # actually turning it off.
+            #
+            # Confirmed via WS sniffing of the device's own web UI: setting
+            # brightness requires BOTH settings.rgb_info_brightness (as a
+            # string) AND led.brightness (as an int) - the device does not
+            # propagate the former into the latter on its own, and
+            # led.brightness is the field this entity reads back for
+            # display, so sending only the settings side left the UI
+            # permanently stale regardless of how long a refresh waited.
+            device_brightness = max(1, round(kwargs[ATTR_BRIGHTNESS] / 255 * 100))
+            settings["rgb_info_brightness"] = str(device_brightness)
+            led["brightness"] = device_brightness
+
+        payload = json.dumps({"settings": settings, "led": led})
+        await self.coordinator.config_entry.runtime_data.client.async_send(payload)
+
+        # Update local state optimistically - this is the value the UI
+        # shows immediately, ahead of the delayed reconciliation below.
+        self._attr_is_on = True
+        if device_brightness is not None:
+            self._attr_brightness = round(device_brightness / 100 * 255)
+        self.async_write_ha_state()
+
+        self.hass.async_create_task(self._async_reconcile_after_delay())
+
+    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
+        """Turn off the RGB Idle Light without touching brightness."""
+        payload = json.dumps(
+            {
+                "settings": {"on": False, "current_mode": self._current_mode()},
+                "led": {"on": False},
+            }
+        )
+        await self.coordinator.config_entry.runtime_data.client.async_send(payload)
+
+        # See async_turn_on for why this is set optimistically rather than
+        # waiting solely on a refresh.
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+        self.hass.async_create_task(self._async_reconcile_after_delay())

--- a/custom_components/panda_status/switch.py
+++ b/custom_components/panda_status/switch.py
@@ -45,16 +45,6 @@ async def async_setup_entry(
                     device_class=SwitchDeviceClass.SWITCH,
                 ),
             ),
-            PandaStatusRGBIdleSwitch(
-                coordinator=coordinator,
-                entity_description=SwitchEntityDescription(
-                    key="rgb_idle_light",
-                    name="RGB Idle Light",
-                    icon="mdi:lightbulb",
-                    entity_category=EntityCategory.CONFIG,
-                    device_class=SwitchDeviceClass.SWITCH,
-                ),
-            ),
         ]
     )
 
@@ -105,53 +95,3 @@ class PandaStatusAPSwitch(PandaStatusEntity, SwitchEntity):
         )
         await self.coordinator.async_request_refresh()
 
-
-class PandaStatusRGBIdleSwitch(PandaStatusEntity, SwitchEntity):
-    """Representation of the RGB Idle Light Switch."""
-
-    def __init__(
-        self,
-        coordinator: PandaStatusDataUpdateCoordinator,
-        entity_description: SwitchEntityDescription,
-    ) -> None:
-        """
-        Initialize the RGB Idle Light Switch entity.
-
-        Args:
-            coordinator: The data update coordinator for panda_status.
-            entity_description: Description of the switch entity.
-
-        """
-        super().__init__(coordinator, entity_description)
-        self.entity_description = entity_description
-        self._attr_is_on = self._get_state_from_data()
-
-    def _get_state_from_data(self) -> bool | None:
-        """Get the current state from coordinator data."""
-        last_msg = self.coordinator.data
-        if last_msg and "settings" in last_msg:
-            list2 = last_msg["settings"].get("list2", [])
-            if len(list2) > 1:
-                return list2[1].get("brightness", 0) > 0
-            return False
-        return None
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._attr_is_on = self._get_state_from_data()
-        self.async_write_ha_state()
-
-    async def async_turn_on(self, **kwargs: Any) -> None:  # noqa: ARG002
-        """Turn on the RGB Idle Light."""
-        await self.coordinator.config_entry.runtime_data.client.async_send(
-            '{"settings":{"rgb_info_brightness":"100"}}'
-        )
-        await self.coordinator.async_request_refresh()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
-        """Turn off the RGB Idle Light."""
-        await self.coordinator.config_entry.runtime_data.client.async_send(
-            '{"settings":{"rgb_info_brightness":"0"}}'
-        )
-        await self.coordinator.async_request_refresh()

--- a/custom_components/panda_status/switch.py
+++ b/custom_components/panda_status/switch.py
@@ -94,4 +94,3 @@ class PandaStatusAPSwitch(PandaStatusEntity, SwitchEntity):
             '{"ap":{"on":0}}'
         )
         await self.coordinator.async_request_refresh()
-

--- a/custom_components/panda_status/websocket.py
+++ b/custom_components/panda_status/websocket.py
@@ -62,7 +62,12 @@ class PandaStatusWebSocket:
 
         """
         try:
-            async with asyncio.timeout(1):
+            # 1 second was workable when this connection only ever happened
+            # right after a user action; now that the coordinator polls
+            # periodically, that budget is regularly too tight for the
+            # device's own connect+respond time and was causing frequent
+            # false-negative "unavailable" flaps.
+            async with asyncio.timeout(5):
                 async with self._session as websocket:
                     data = json.loads(await websocket.recv())
         except TimeoutError as e:
@@ -93,7 +98,7 @@ class PandaStatusWebSocket:
         """
         try:
             _LOGGER.debug("Sending payload: %s", payload)
-            async with asyncio.timeout(1):
+            async with asyncio.timeout(5):
                 async with self._session as websocket:
                     await websocket.send(payload)
                     _LOGGER.debug("Payload sent: %s", payload)


### PR DESCRIPTION
## Replace RGB Idle Light switch with a proper light entity (on/off + brightness)

### Summary

The `rgb_idle_light` switch faked "on/off" by slamming brightness to 100%/0%,
which meant turning it on always destroyed any custom brightness you'd set,
and caused a double-toggle bug where the first tap just resynced state and
the second one actually flipped the light. This PR replaces it with a proper
`light` entity that uses the device's real on/off flag, kept entirely
separate from brightness, plus working brightness control.

### Problem

```python
# old behaviour
def _get_state_from_data(self) -> bool | None:
    ...
    return list2[1].get("brightness", 0) > 0  # "on" inferred from brightness

async def async_turn_on(self, **kwargs):
    await client.async_send('{"settings":{"rgb_info_brightness":"100"}}')

async def async_turn_off(self, **kwargs):
    await client.async_send('{"settings":{"rgb_info_brightness":"0"}}')
```

There's no real on/off state here at all - `is_on` is inferred from
`brightness > 0`, and `turn_on`/`turn_off` just hammer brightness to 100 or
0. Two visible symptoms:

- **Custom brightness gets wiped** every time the light is turned on, since
  "on" and "brightness = 100" were treated as the same thing.
- **Double-toggle required to turn on** - HA's optimistic state and the
  derived `brightness > 0` boolean would drift apart, so the first tap just
  resynced them and the second one actually worked.

### Root cause (found via WebSocket sniffing against the device)

The firmware exposes real, independent state for on/off and brightness that
this integration was never using:

| Concept | Real field(s) |
|---|---|
| On/off | `led.on` (read) / `led.on` + `settings.on` + `settings.current_mode` (write, must be sent together in one message) |
| Brightness | `led.brightness` (read) / `led.brightness` (int) + `settings.rgb_info_brightness` (string) (write, must be sent together) |

Two non-obvious things turned up during testing directly against the device
with `websocat` (not just capturing the web UI, since one of its captured
keys turned out to be a red herring):

1. **On/off must be sent as a single atomic payload including
   `settings.current_mode`** - the device will not turn off without it:
   ```json
   {"settings":{"on":false,"current_mode":0},"led":{"on":false}}
   ```
   Sending `led.on` and `settings.on` as two separate messages (which is
   what the web UI's own network capture appeared to do) is not reliable.

2. **Brightness needs both `led.brightness` (int) and
   `settings.rgb_info_brightness` (string) together** - the settings side
   does not propagate into `led.brightness` on its own, and `led.brightness`
   is the field that reflects the live, current state. Writing only
   `settings.rgb_info_brightness` (as the original switch did) changes the
   physical light but leaves the reported state permanently stale:
   ```json
   {"led":{"brightness":84},"settings":{"rgb_info_brightness":"84"}}
   ```

Also discovered along the way: the coordinator had no `update_interval` set
at all, meaning it only ever refreshed when an entity action explicitly
triggered it - immediately after sending a command. Combined with the
device using a brand-new WebSocket connection per call (see
`websocket.py`), an action-triggered refresh could race the device's own
internal state update and read back stale data, with nothing to
self-correct it afterwards. Adding periodic polling to fix that exposed a
second, pre-existing issue: `async_get_data`/`async_send` used a hard
**1-second timeout** covering the full connect+handshake+respond cycle,
with no retry. That budget was rarely tested when connections only
happened right after a user action, but polling every 30s continuously
(~2,880 times/day) reliably caught the device's embedded WS stack on a slow
beat often enough to flap the whole integration to `unavailable` several
times an hour. Fixed by loosening the timeout to 5s, retrying once on a
timeout before treating it as a real failure, and backing the poll interval
off to 60s.

### Changes

- **`light.py`** (new) - `rgb_idle_light` is now a `ColorMode.BRIGHTNESS`
  light entity:
  - State reads `led.on` / `led.brightness` directly instead of inferring
    on/off from brightness.
  - `turn_on`/`turn_off` send the atomic payloads described above.
  - Local state is updated optimistically so the UI responds instantly,
    with a reconciliation refresh run as a delayed background task (not
    inline) so it doesn't race the device's own state update.
- **`switch.py`** - `PandaStatusRGBIdleSwitch` removed. `PandaStatusAPSwitch`
  is untouched.
- **`websocket.py`** - timeout on both `async_get_data` and `async_send`
  raised from 1s to 5s, giving the device's embedded WS stack realistic
  breathing room now that polling happens continuously rather than only
  right after user actions.
- **`coordinator.py`** - a single timeout is now retried once before being
  raised as a real `UpdateFailed`, so one slow poll doesn't flap entities to
  unavailable.
- **`__init__.py`**
  - `Platform.LIGHT` added to `PLATFORMS`.
  - Coordinator now has `update_interval=timedelta(seconds=60)`, so state
    self-corrects periodically regardless of what individual actions do,
    without hammering the device's WS stack too aggressively.

### Breaking change

`switch.<device>_rgb_idle_light` is removed and replaced by
`light.<device>_rgb_idle_light`. Any automations, scripts, or dashboards
referencing the old switch entity will need to be updated to point at the
new light entity. Given this, it's probably worth a `3.0.0` version bump
rather than a patch/minor release.

### Testing

Manually tested against a live device (BTT Panda Status on a Bambu A1 mini)
over several days:

- On/off toggling from the HA UI - no more double-toggle.
- Brightness slider while the light is on - updates the physical light and
  the displayed value correctly.
- Turning off and back on preserves the previously set brightness instead
  of resetting it.
- HA restart - state comes back correctly from the first coordinator poll.
- Toggling via automations (not just manual UI interaction) - works
  correctly.
- Left running for several days after the timeout/polling-interval fix -
  no further `unavailable` flapping observed (was happening several times
  an hour before that fix).

Not yet covered: behaviour under rapid repeated brightness changes (e.g.
fast slider dragging), which may still exhibit minor last-write-wins
ordering issues given the device's one-connection-per-command design - this
appears to be a protocol-level limitation rather than something fixable
purely on the entity side, and could be revisited with command debouncing
if it turns out to matter in practice.
